### PR TITLE
HSIO negotation fix

### DIFF
--- a/altirra-custom-device/netsio.atdevice
+++ b/altirra-custom-device/netsio.atdevice
@@ -52,6 +52,7 @@ int processing_pclink_parblk;
 int block_dev1;
 int block_dev2;
 int skip_current_command;
+int hsio_pending;
 
 Thread command_thread;
 Thread motor_thread;
@@ -156,6 +157,7 @@ function void debug_command_frame()
         else if(cmd == $2B) {Debug.log("Network RMDIR"); write_size_hint = 257;}
         else if(cmd == $2C) {Debug.log("Network CHDIR"); write_size_hint = 257;}
         else if(cmd == $30) Debug.log("Network PWD");
+        else if(cmd == $3F) {Debug.log("Network GET HSIO"); hsio_pending = 1;}
         else if(cmd == $FC) Debug.log_int("Network SET Channel Mode ", aux2);
         else if(cmd == $FD) {Debug.log("Network Set LOGIN"); write_size_hint = 257;}
         else if(cmd == $FE) {Debug.log("Network Set PASSWORD"); write_size_hint = 257;}
@@ -448,15 +450,26 @@ function void rxbyte_thread_handler()
         rxbyte = $sio.recv_raw_byte();
         //$network.post_message($103, 2); // debug nop
         if (out_cpb != $aux) {
-            Debug.log_int("CPB: ", $aux);
-            //$network.post_message($103, 3); // debug nop
-            buffer_to_server();
-            out_cpb = $aux;
-            //baud = 1789773 / $aux;
-            baud = 1789760 / $aux;
-            Debug.log_int("NetSIO from Atari @ ", baud);
-            $network.post_message($80, baud);
-            //$network.post_message($103, 4); // debug nop
+            if (hsio_pending) {
+                // HSIO negotiated — update both directions locally
+                // Do NOT send event $80 to FujiNet-PC (would cause data corruption)
+                buffer_to_server();
+                out_cpb = $aux;
+                in_cpb = $aux;
+                hsio_pending = 0;
+                baud = 1789760 / $aux;
+                Debug.log_int("HSIO active @ ", baud);
+            } else {
+                Debug.log_int("CPB: ", $aux);
+                //$network.post_message($103, 3); // debug nop
+                buffer_to_server();
+                out_cpb = $aux;
+                //baud = 1789773 / $aux;
+                baud = 1789760 / $aux;
+                Debug.log_int("NetSIO from Atari @ ", baud);
+                $network.post_message($80, baud);
+                //$network.post_message($103, 4); // debug nop
+            }
         }
         if (sync_write_size) {
             sync_write_size = sync_write_size - 1;
@@ -631,6 +644,7 @@ event "cold_reset": function
     block_dev1 = $4F; // Poll3, -1 to deactivate
     block_dev2 = $6F; // $6F for PCLink, -1 to deactivate
     skip_current_command = 0;
+    hsio_pending = 0;
 
     processing_pclink_parblk = 0;
 

--- a/altirra-custom-device/netsio.atdevice
+++ b/altirra-custom-device/netsio.atdevice
@@ -644,7 +644,7 @@ event "cold_reset": function
     block_dev1 = $4F; // Poll3, -1 to deactivate
     block_dev2 = $6F; // $6F for PCLink, -1 to deactivate
     skip_current_command = 0;
-    hsio_pending = 0;
+    hsio_pending = 1;
 
     processing_pclink_parblk = 0;
 


### PR DESCRIPTION
# Extras

## `altirra-custom-device/netsio.atdevice`

Modified NetSIO custom device script for the Altirra emulator with HSIO (High-Speed SIO) support.  This file bridges the Altirra emulator to FujiNet-PC over a network socket, handling the SIO protocol translation including high-speed transfers.

### HSIO Changes

Four modifications were made to the original `netsio.atdevice` to support HSIO negotiation initiated by the Atari side:

1. **`int hsio_pending`** (line 55) — new state variable, tracks whether a `$3F` (Get High Speed Index) command was recently sent to a network device.

2. **`$3F` detection** (line 160) — in `debug_command_frame()`, when command `$3F` is seen for a network device (`$71`), sets `hsio_pending = 1`.

3. **Speed detection** (lines 452–473) — in `rxbyte_thread_handler()`, when a baud rate change is detected (`out_cpb != $aux`):
   - If `hsio_pending == 1`: updates **both** `out_cpb` and `in_cpb` locally, clears `hsio_pending`, and does **not** send event `$80` to FujiNet-PC.
   - If `hsio_pending == 0`: standard behavior — updates `out_cpb` only and sends event `$80` to FujiNet-PC.

4. **Cold reset** (line 647) — clears `hsio_pending = 0` on system reset.

### Why No Event `$80`

When HSIO is negotiated, NetSIO must NOT send event `$80` (baud rate change notification) to FujiNet-PC.  In FujiNet-PC's `handle_netsio()` function, if `_baud_peer` differs from `_baud` by more than 10%, all received bytes are XOR-corrupted as a speed-mismatch error indicator. Since FujiNet-PC's internal `_baud` stays at 19200 while the SIO bus switches to ~112 kbit/s, sending `$80` would trigger this corruption.

The local-only update (changing both `in_cpb` and `out_cpb` inside NetSIO without notifying FujiNet-PC) avoids the problem.  FujiNet-PC continues to send/receive data at its own rate, and NetSIO handles the speed translation transparently.